### PR TITLE
Add gitignore and note about ignored subtitles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,94 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.pyc
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+.env.local
+.env.*.local
+
+# virtualenv
+venv/
+ENV/
+env/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# profiling data
+prof/
+
+# OS specific
+.DS_Store
+Thumbs.db
+
+# Local subtitles output
+subtitles.txt
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A small tool to download subtitles from YouTube videos.
    ```
    Replace `<VIDEO_URL>` with the link to the video and adjust the language code if necessary.
 
+Note: `subtitles.txt` is listed in `.gitignore`, so generated subtitles are ignored by Git.
+
 ## GitHub Actions
 
 The repository includes a workflow that can be triggered manually to scrape subtitles and provide them as a build artifact.


### PR DESCRIPTION
## Summary
- add a `.gitignore` with common Python patterns and ignore `subtitles.txt`
- note in the README that the subtitle file is ignored

## Testing
- `python -m py_compile subtitle_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_684d0f6045cc8327a471849ecfb0a8e1